### PR TITLE
Core: Add controller for creating api keys

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -1,0 +1,10 @@
+import { createApiKey } from "../services/api.service.js";
+
+// Controller for creating an api key
+async function createApiKeyController(req, res) {
+    const userId = req.user.id; // Assuming user ID is available in req.user
+    const apiKey = await createApiKey(userId);
+    res.status(201).json(apiKey);
+};
+
+export { createApiKeyController };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,4 +1,8 @@
-import { loginUser, registerUser, refreshUserToken } from "../services/auth.service.js";
+import {
+  loginUser,
+  registerUser,
+  refreshUserToken,
+} from "../services/auth.service.js";
 import env from "../config/env.js";
 
 async function login(req, res) {

--- a/src/models/ApiKey.js
+++ b/src/models/ApiKey.js
@@ -10,6 +10,10 @@ ApiKey.init(
       defaultValue: DataTypes.UUIDV4,
       primaryKey: true,
     },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
     key: DataTypes.STRING,
     secret: DataTypes.STRING,
     status: {

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -1,0 +1,24 @@
+import { ApiKey } from "../models/ApiKey.js";
+import bcrypt from "bcrypt";
+import crypto from "crypto";
+
+// Create a new API key
+const createApiKey = async (userId) => {
+  const apiKey = "layerpay_pk_" + crypto.randomBytes(16).toString("hex");
+  const apiSecretRaw = "layerpay_sk_" + crypto.randomBytes(32).toString("hex");
+
+  // Hash the secret
+  const apiSecretHash = await bcrypt.hash(apiSecretRaw, 12);
+
+  // Save (public + hash)
+  const api = await ApiKey.create({
+    userId,
+    key: apiKey,
+    secret: apiSecretHash,
+    status: "active",
+  });
+
+  return api;
+};
+
+export { createApiKey };


### PR DESCRIPTION
This pull request introduces a new API key management feature, allowing users to generate API keys tied to their accounts. The main changes include adding a controller and service for API key creation, updating the `ApiKey` model to associate keys with users, and implementing secure key/secret generation and storage.

**API Key Management Feature:**

* Added a new `createApiKeyController` in `apiController.js` to handle API key creation requests, returning the generated key for the authenticated user.
* Implemented a `createApiKey` service in `api.service.js` that generates a unique public key and a securely hashed secret, associates them with the user, and stores them in the database.
* Updated the `ApiKey` model in `ApiKey.js` to include a required `userId` field, ensuring each API key is linked to a user.

**Minor Code Style/Organization:**

* Reformatted imports in `authController.js` for readability; no functional changes.