### PR TITLE
Core: Add route for api key management

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -2,7 +2,7 @@ import { createApiKey } from "../services/api.service.js";
 
 // Controller for creating an api key
 async function createApiKeyController(req, res) {
-    const userId = req.user.id; // Assuming user ID is available in req.user
+    const userId = req.user.id;
     const apiKey = await createApiKey(userId);
     res.status(201).json(apiKey);
 };

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { createApiKeyController } from "../controllers/apiController";
+import { authMiddleware } from "../middleware/authMiddleware";
+
+const router = Router();
+
+router.post("/api-keys", authMiddleware, createApiKeyController);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import authRoutes from "./authRoutes.js";
+import apiRoutes from "./apiRoutes.js";
 // import paymentRoutes from "./paymentRoutes.js";
 
 const router = Router();
 
 router.use("/auth", authRoutes);
+router.use("/api", apiRoutes);
 // router.use("/payments", paymentRoutes);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new API route for creating API keys, including the necessary controller, routing, and middleware integration. The main focus is on enabling authenticated users to generate API keys through a dedicated endpoint.

**API Key Creation Feature:**

* Added a new route `/api/api-keys` that allows authenticated users to create API keys. This route uses the `authMiddleware` to ensure only logged-in users can access it, and delegates the request to `createApiKeyController`. (`src/routes/apiRoutes.js`, [src/routes/apiRoutes.jsR1-R9](diffhunk://#diff-0627657e9ae54e978ced9a277cdce26557283cf9456657f574677cf053c58855R1-R9))
* Registered the new API routes under the `/api` path in the main router to make the new endpoint accessible. (`src/routes/index.js`, [src/routes/index.jsR3-R9](diffhunk://#diff-268a45f8e3c5fba5953593271f7aaed3d91812853a17dea472417fcc17c84bfdR3-R9))

**Controller Logic:**

* The `createApiKeyController` now retrieves the user ID from the authenticated request and uses the `createApiKey` service to generate a new API key, returning it as a JSON response. (`src/controllers/apiController.js`, [src/controllers/apiController.jsL5-R5](diffhunk://#diff-d153f7684753732b2cf4d8380c500f056fffd63a61ad4aa76556a8b27bbd2113L5-R5))