### PR TITLE
Fix: Ensure only merchants the user belongs to are returned

### DIFF
--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -22,11 +22,14 @@ async function loginUser(email, password) {
     include: [
       {
         model: MerchantUser,
-        where: { userId: user.id },
         attributes: ["role"],
+        where: { userId: user.id },
+        required: true,
       },
     ],
   });
+
+  console.log("Merchants:", merchants);
 
   const accessToken = generateAccessToken(user.id);
   const refreshToken = generateRefreshToken(user.id);
@@ -40,7 +43,7 @@ async function loginUser(email, password) {
     merchants: merchants.map((m) => ({
       id: m.id,
       name: m.name,
-      role: m.merchant_users[0].role, // role from join table
+      role: m.merchantUsers[0].role, // role from join table
     })),
     accessToken,
     refreshToken,


### PR DESCRIPTION
This pull request makes minor improvements to the `loginUser` function in `src/services/auth.service.js`, focusing on query reliability and data access consistency.

- Query reliability:
  * Added `required: true` to the `MerchantUser` model include, ensuring only merchants associated with the user are returned.

- Data access consistency:
  * Fixed a property name from `merchant_users` to `merchantUsers` when accessing the user's role from the join table.

Additionally, a debug log statement was added to output the merchants returned by the query.