### PR TITLE
Fix: Add merchantId to url params

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -7,6 +7,7 @@ import {
 // Controller for creating an api key
 async function createApiKeyController(req, res) {
   const userId = req.user.id;
+  const project = req.body.project;
   const merchantId = req.params.merchantId;
   const apiKey = await createApiKey(userId, merchantId, project);
   res.status(201).json(apiKey);

--- a/src/models/ApiKey.js
+++ b/src/models/ApiKey.js
@@ -12,7 +12,7 @@ ApiKey.init(
     },
     label: { type: DataTypes.STRING },
     hashedKey: { type: DataTypes.STRING, allowNull: false },
-    scope: { type: DataTypes.JSONB },
+    scope: { type: DataTypes.ARRAY(DataTypes.STRING), defaultValue: ["read"] },
     lastUsedAt: { type: DataTypes.DATE },
     revokedAt: { type: DataTypes.DATE },
   },

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -8,8 +8,8 @@ import { authMiddleware } from "../middleware/authMiddleware.js";
 
 const router = Router();
 
-router.post("/api-keys", authMiddleware, createApiKeyController);
-router.get("/api-keys", authMiddleware, getApiKeysController);
-router.post("/api-keys/:apiKey/revoke", authMiddleware, revokeApiKeyController);
+router.post("/api-keys/:merchantId", authMiddleware, createApiKeyController);
+router.get("/api-keys/:merchantId", authMiddleware, getApiKeysController);
+router.post("/api-keys/:merchantId/:apiKey/revoke", authMiddleware, revokeApiKeyController);
 
 export default router;

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -27,9 +27,9 @@ const createApiKey = async (userId, merchantId, project) => {
 
   const api = await ApiKey.create({
     merchantId,
-    project,
+    label: project,
     key: apiKey,
-    secret: apiSecretHash,
+    hashedKey: apiSecretHash,
     status: "active",
   });
 


### PR DESCRIPTION
This pull request introduces several updates to the API key management system, focusing on improving the API key model, updating route structures, and clarifying the handling of API key creation. The main changes include restructuring the API key routes to be merchant-specific, adjusting the API key model's `scope` attribute, and clarifying the mapping of request parameters and model fields during API key creation.

**API route structure improvements:**

* Updated API key-related routes in `src/routes/apiRoutes.js` to include `merchantId` as a URL parameter, making all API key operations explicitly merchant-scoped.

**API key creation and model adjustments:**

* Modified the API key creation controller in `src/controllers/apiController.js` to accept a `project` parameter from the request body and pass it to the service layer.
* Updated the service layer in `src/services/api.service.js` to map the incoming `project` parameter to the `label` field and to use `hashedKey` instead of `secret` when creating a new API key.
* Changed the `scope` field in the `ApiKey` model (`src/models/ApiKey.js`) from a JSONB type to an array of strings with a default value of `["read"]`, standardizing the way scopes are stored and providing a sensible default.