### PR TITLE
Fix: Add status column in apiKey model

### DIFF
--- a/src/models/ApiKey.js
+++ b/src/models/ApiKey.js
@@ -14,6 +14,10 @@ ApiKey.init(
     key: { type: DataTypes.STRING, allowNull: false, unique: true },
     hashedKey: { type: DataTypes.STRING, allowNull: false },
     scope: { type: DataTypes.ARRAY(DataTypes.STRING), defaultValue: ["read"] },
+    status: {
+      type: DataTypes.ENUM("active", "revoked"),
+      defaultValue: "active",
+    },
     lastUsedAt: { type: DataTypes.DATE },
     revokedAt: { type: DataTypes.DATE },
   },

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -10,6 +10,10 @@ const router = Router();
 
 router.post("/api-keys/:merchantId", authMiddleware, createApiKeyController);
 router.get("/api-keys/:merchantId", authMiddleware, getApiKeysController);
-router.post("/api-keys/:merchantId/:apiKey/revoke", authMiddleware, revokeApiKeyController);
+router.post(
+  "/api-keys/:merchantId/:apiKey/revoke",
+  authMiddleware,
+  revokeApiKeyController
+);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new `status` field to the `ApiKey` model to better track the state of API keys, and also makes a minor formatting change to the API key revocation route for improved readability.

**API Key Model Enhancements:**

* Added a `status` field to the `ApiKey` model as an ENUM with values `"active"` and `"revoked"`, defaulting to `"active"`. This will help in explicitly tracking whether an API key is currently active or has been revoked.

**Code Formatting Improvements:**

* Reformatted the API key revocation route definition in `apiRoutes.js` for better readability, splitting the parameters onto separate lines.