### PR TITLE
Fix: Add role-based access control middleware

### DIFF
--- a/src/middleware/roleMiddleware.js
+++ b/src/middleware/roleMiddleware.js
@@ -1,0 +1,28 @@
+export function requireRole(allowedRoles = []) {
+  return (req, res, next) => {
+    try {
+      const user = req.user;
+
+      if (!user) {
+        return res.status(401).json({
+          success: false,
+          error: "Unauthorized: No user in request",
+        });
+      }
+
+      if (!allowedRoles.includes(user.role)) {
+        return res.status(403).json({
+          success: false,
+          error: `Forbidden: Requires role ${allowedRoles.join(" or ")}`,
+        });
+      }
+
+      next();
+    } catch (err) {
+      return res.status(500).json({
+        success: false,
+        error: "Server error in role middleware",
+      });
+    }
+  };
+}

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { authMiddleware } from "../middleware/authMiddleware.js";
+import { requireRole } from "../middleware/roleMiddleware.js";
 import { changeRoleController } from "../controllers/userController.js";
 
 const router = Router();
 
-router.post("/change-role", authMiddleware, changeRoleController);
+router.post("/change-role", authMiddleware, requireRole(["admin"]), changeRoleController);
 
 export default router;


### PR DESCRIPTION
This pull request introduces role-based access control for the user role change endpoint. The main change is the addition of middleware to ensure that only users with the "admin" role can access the `/change-role` route.

**Role-based access control:**

* Added a new `requireRole` middleware in `roleMiddleware.js` to restrict access to routes based on user roles.
* Updated the `/change-role` route in `userRoutes.js` to use the `requireRole(["admin"])` middleware, so only admins can change user roles.