### PR TITLE
Fix: Correct imports in EmailOtp model

### DIFF
--- a/src/models/EmailOtp.js
+++ b/src/models/EmailOtp.js
@@ -1,5 +1,5 @@
-import { DataTypes, Model } from "sequelize";
-import { sequelize } from "../db.js";
+import { Model, DataTypes } from "sequelize";
+import sequelize from "../config/database.js";
 import crypto from "crypto";
 
 export class EmailOtp extends Model {


### PR DESCRIPTION
This pull request makes a minor update to the import statements in the `EmailOtp` model to improve consistency and maintainability.

- Refactored the import of `sequelize` to use the centralized configuration in `config/database.js` instead of importing directly from `db.js` in `src/models/EmailOtp.js`.